### PR TITLE
print port and ip address info in chunks.

### DIFF
--- a/netshow/linux/print_bond.py
+++ b/netshow/linux/print_bond.py
@@ -101,7 +101,7 @@ class PrintBond(PrintIface):
         """
         _arr = []
         _arr.append(self.print_bondmems())
-        _arr.append(self.ip_info())
+        _arr += PrintIface.summary.fget(self)
         if self.iface.is_trunk():
             _arr += self.trunk_summary()
         elif self.iface.is_access():

--- a/netshow/linux/print_bridge.py
+++ b/netshow/linux/print_bridge.py
@@ -60,8 +60,7 @@ class PrintBridge(PrintIface):
         """
         :return: summary information regarding the bridge
         """
-        _info = []
-        _info.append(self.ip_info())
+        _info = PrintIface.summary.fget(self)
         _info.append(self.vlan_id_field())
         _info.append(self.stp_summary())
         for _entry in self.untagged_ifaces():
@@ -78,7 +77,7 @@ class PrintBridge(PrintIface):
         _untagmems = self.iface.untagged_members.keys()
         if _untagmems:
             _str = []
-            self.print_portlist_in_chunks(_untagmems, _('untagged_members'), _str)
+            self.print_list_in_chunks(_untagmems, _('untagged_members'), _str)
             return _str
         return []
 
@@ -89,7 +88,7 @@ class PrintBridge(PrintIface):
         _tagmems = self.iface.tagged_members.keys()
         if _tagmems:
             _str = []
-            self.print_portlist_in_chunks(_tagmems, _('tagged_members'), _str)
+            self.print_list_in_chunks(_tagmems, _('tagged_members'), _str)
             return _str
         return []
 
@@ -168,7 +167,7 @@ class PrintBridge(PrintIface):
         _table = []
         memberlist = self.iface.members.keys()
         _table2 = []
-        self.print_portlist_in_chunks(memberlist, '', _table2)
+        self.print_list_in_chunks(memberlist, '', _table2)
         _table.append([_('bridge_members') + ':',  _table2[0]])
         for i in range(1, len(_table2)):
             _table.append(['', _table2[i]])
@@ -184,7 +183,7 @@ class PrintBridge(PrintIface):
                      self.iface.stp.member_state.get(statename)]
         if _portlist:
             _table2 = []
-            self.print_portlist_in_chunks(_portlist, '', _table2)
+            self.print_list_in_chunks(_portlist, '', _table2)
             for i in _table2:
                 _table.append([i])
             return tabulate(_table, _header) + self.new_line()
@@ -196,7 +195,9 @@ class PrintBridge(PrintIface):
         """
         _str = one_line_legend(show_legend)
         _str += self.cli_header()
-        _str += self.ip_details()
+        _ip_details = self.ip_details()
+        if _ip_details:
+            _str += self.ip_details()
         if self.iface.stp:
             _str += self.stp_details()
             for _state in ['forwarding', 'blocking']:

--- a/netshow/linux/print_iface.py
+++ b/netshow/linux/print_iface.py
@@ -109,22 +109,23 @@ class PrintIface(object):
         return _str
 
     def ip_info(self):
+        _arr = ['']
         if self.iface.is_l3():
-            _str2 = ""
+            _arr = []
             if self.iface.ip_addr_assign == 1:
-                _str2 = "(%s)" % _('dhcp')
-
-            _str = _('ip') + ': ' + \
-                ', '.join(self.iface.ip_address.allentries) + _str2
-            return _str
-        return ''
+                first_addr = self.iface.ip_address.allentries[0]
+                _arr.append("%s: %s(%s)" % (_('ip'), first_addr, _('dhcp')))
+            else:
+                self.print_list_in_chunks(self.iface.ip_address.allentries,
+                                          _('ip'), _arr)
+        return _arr
 
     @property
     def summary(self):
         """
         :return: summary information regarding the interface
         """
-        return [self.ip_info()]
+        return self.ip_info()
 
     def cli_header(self):
         """
@@ -145,10 +146,13 @@ class PrintIface(object):
 
     def cli_output(self, show_legend=False):
         """
-        :params: show_legend. if set to to true, will show legend, otherwise will show just one line. message
-        telling user to run "netshow" with -l option
         Each PrintIface child should define their own  of this function
-        :return: output for 'netshow interface <ifacename>'
+        Args:
+            show_legend:  if set to to true, will show legend,
+                        otherwise will show just one line. message
+                        telling user to run "netshow" with -l option
+        Returns:
+            output for 'netshow interface <ifacename>'
         """
         _str = one_line_legend(show_legend)
         _str += self.cli_header()
@@ -166,8 +170,8 @@ class PrintIface(object):
         if not self.iface.is_l3():
             return ''
         else:
-            _table.append(["%s:" % (_('ip')),
-                           ', '.join(self.iface.ip_address.allentries)])
+            self.print_list_in_chunks(self.iface.ip_address.allentries,
+                                      _('ip'), _table, place_in_list=False, break_into_list=True)
             _table.append(["%s:" % (_('arp_entries')),
                            len(self.iface.ip_neighbor.allentries)])
 
@@ -207,27 +211,65 @@ class PrintIface(object):
             else:
                 native_bridges.append(_bridgename)
         _strlist = [_('bridge_membership') + ':']
-        self.print_portlist_in_chunks(tagged_bridges, _('tagged'), _strlist)
-        self.print_portlist_in_chunks(native_bridges, _('untagged'), _strlist)
+        self.print_list_in_chunks(tagged_bridges, _('tagged'), _strlist)
+        self.print_list_in_chunks(native_bridges, _('untagged'), _strlist)
 
         return _strlist
 
-    def print_portlist_in_chunks(self, portlist, _title, _strlist, shorten_to=4):
+    def print_list_in_chunks(self, listofstuff, _title, _result,
+                             place_in_list=False, break_into_list=False,
+                             shorten_to=4):
         """
         take a long  array of bridge names and break it up into smaller groups of
         arrays based on shorten_to variable
         Reference: http://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks-in-python
-        """
-        if portlist:
-            portlist = sorted(common.group_ports(portlist))
-            portlist = [portlist[_x:_x+shorten_to]
-                        for _x in range(0, len(portlist), shorten_to)]
-            for _idx, _arrlist in enumerate(portlist):
+        Args:
+            listofstuff (list):  list of things that in are in a long list
+                                 that you want to break up into chunks
+            _title (str): heading of the list of stuff you want cut up in chunks
+            _result (list): The list where the chunks will be stored.
+            place_in_list (boolean): Some data needs to be returned as a
+                                    list in a list. Others do not.
+                                     Setting to this true means that you
+                                     want the _result returned to be a list of list
+                                     Example ['1.1.1.1/24'] becomes ["ip: 1.1.1.1/24"]
+                                     Default: False
+            break_into_list (boolean): When printing detailed IP info, print out each entry as a list.
+                                      for example [1.1.1.1/24] becomes ["ip:", "1.1.1.1/24"]
+                                    Default: False
+            shorten_to (int): How many elements are to be placed in each chunk.
+                              Default: 4
+                """
+        if listofstuff:
+            listofstuff = sorted(common.group_ports(listofstuff))
+            listofstuff = [listofstuff[_x:_x+shorten_to]
+                           for _x in range(0, len(listofstuff), shorten_to)]
+            for _idx, _arrlist in enumerate(listofstuff):
                 joined_arrlist = ', '.join(_arrlist)
                 if _idx == 0 and _title:
-                    _strlist.append(_title + ': ' + joined_arrlist)
+                    if break_into_list:
+                        entry = [_title + ':', joined_arrlist]
+                    else:
+                        entry = _title + ': ' + joined_arrlist
+
+                    if place_in_list:
+                        arr_entry = [entry]
+                    else:
+                        arr_entry = entry
+
+                    _result.append(arr_entry)
                 else:
-                    _strlist.append('    ' + joined_arrlist)
+                    if break_into_list:
+                        entry = ['', joined_arrlist]
+                    else:
+                        entry = '    ' + joined_arrlist
+
+                    if place_in_list:
+                        arr_entry = [entry]
+                    else:
+                        arr_entry = entry
+
+                    _result.append(arr_entry)
 
     def access_summary(self):
         """

--- a/tests/test_netshow/test_print_bond.py
+++ b/tests/test_netshow/test_print_bond.py
@@ -299,9 +299,12 @@ class TestPrintBond(object):
         self.piface.iface.is_l3 = mock_is_l3
         self.piface.iface.is_trunk = mock_is_trunk
         self.piface.iface.is_access = mock_is_access
-        self.piface.iface.ip_address.ipv4 = ['10.1.1.1/24']
+        self.piface.iface.ip_address.ipv4 = ['10.1.1.1/32', '10.1.1.2/32',
+                                             '10.1.1.3/32', '10.1.1.4/32', '10.1.1.5/32']
         _output = self.piface.summary
-        assert_equals(_output, ['list of bondmembers', 'ip: 10.1.1.1/24'])
+        assert_equals(_output, ['list of bondmembers',
+                                'ip: 10.1.1.1/32, 10.1.1.2/32, 10.1.1.3/32, 10.1.1.4/32',
+                                '    10.1.1.5/32'])
         # is not l3 but is a trunk
         mock_is_l3.return_value = False
         mock_is_trunk.return_value = True

--- a/tests/test_netshow/test_print_bridge.py
+++ b/tests/test_netshow/test_print_bridge.py
@@ -216,14 +216,16 @@ class TestPrintBridge(object):
     def test_summary(self, mock_is_l3, mock_vlan_id, mock_tagged, mock_untagged,
                      mock_stp_summary):
         mock_is_l3.return_value = True
-        self.piface.iface.ip_address.ipv4 = ['10.1.1.1/24']
+        self.piface.iface.ip_address.ipv4 = ['10.1.1.1/32', '10.1.1.2/32', '10.1.1.3/32', '10.1.1.4/32',
+                                             '10.1.1.5/32', '10.1.1.6/32', '10.1.1.7/32']
         mock_vlan_id.return_value = 'vlan_id'
         mock_stp_summary.return_value = 'stp_summary'
         mock_tagged.return_value = ['tagged_ifaces']
         mock_untagged.return_value = ['untagged_ifaces']
         _output = self.piface.summary
         assert_equals(_output,
-                      ['ip: 10.1.1.1/24',
+                      ['ip: 10.1.1.1/32, 10.1.1.2/32, 10.1.1.3/32, 10.1.1.4/32',
+                       '    10.1.1.5/32, 10.1.1.6/32, 10.1.1.7/32',
                        '802.1q_tag: vlan_id', 'stp_summary',
                        'untagged_ifaces',
                        'tagged_ifaces',

--- a/tests/test_netshow/test_print_iface.py
+++ b/tests/test_netshow/test_print_iface.py
@@ -20,21 +20,21 @@ import netshowlib.linux.iface as linux_iface
 import netshowlib.linux.bridge as linux_bridge
 import mock
 from asserts import assert_equals, mod_args_generator
-from nose.tools import assert_not_equal
+
 
 class TestPrintIface(object):
     def setup(self):
         iface = linux_iface.Iface('eth22')
         self.piface = print_iface.PrintIface(iface)
 
-    def test_print_portlist_in_chunks(self):
+    def test_print_list_in_chunks(self):
         portlist = ['eth1.20', 'eth2.20', 'eth3.20', 'eth4.20',
                     'eth13.50', 'eth17.50', 'eth20.50', 'eth21.50',
                     'eth30', 'eth40', 'eth44', 'eth55', 'eth60',
                     'eth70', 'eth80', 'eth90', 'eth100']
         title = 'untagged members'
         strlist = []
-        self.piface.print_portlist_in_chunks(portlist, title, strlist)
+        self.piface.print_list_in_chunks(portlist, title, strlist)
         assert_equals(strlist,  ['untagged members: eth1-4.20, eth100, eth13.50, eth17.50',
                                  '    eth20-21.50, eth30, eth40, eth44',
                                  '    eth55, eth60, eth70, eth80',
@@ -166,15 +166,21 @@ class TestPrintIface(object):
         assert_equals(_output, '')
         # if l3, print ip details
         mock_is_l3.return_value = True
-        self.piface.iface.ip_address.ipv4 = ['10.1.1.1/24']
+        self.piface.iface.ip_address.ipv4 = ['10.1.1.1/32', '10.1.1.2/32',
+                                             '10.1.1.3/32', '10.1.1.4/32',
+                                             '10.1.1.5/32']
         self.piface.iface.ip_neighbor._all_neighbors = {
             '10.1.1.2': '222',
             '10.1.1.3': '333'}
         _output = self.piface.ip_details()
         _outputtable = _output.split('\n')
         assert_equals(_outputtable[0], 'ip_details')
-        assert_equals(_outputtable[2].split(), ['ip:', '10.1.1.1/24'])
-        assert_equals(_outputtable[3].split(), ['arp_entries:', '2'])
+        assert_equals(_outputtable[2].split(),
+                      ['ip:', '10.1.1.1/32,', '10.1.1.2/32,',
+                       '10.1.1.3/32,', '10.1.1.4/32'])
+        assert_equals(_outputtable[3].split(),
+                      ['10.1.1.5/32'])
+        assert_equals(_outputtable[4].split(), ['arp_entries:', '2'])
 
     @mock.patch('netshowlib.linux.lldp.Lldp.run')
     def test_lldp_details(self, mock_lldp):


### PR DESCRIPTION
When too many ports or too many interfaces are listed in the terminal…
this feature ensures that it looks a little more pretty than before

TODO: is to perform range calculations where possible.